### PR TITLE
Docker Multi-stage builds

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,12 +1,44 @@
-FROM python:3.10.2
-
-RUN apt update && apt install iputils-ping -y
+FROM python:3.10.2-alpine3.15 AS builder
 
 WORKDIR /api
-COPY . .
 
-RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONDONTWRITEBYTECODE=1
 
+COPY ./requirements.txt .
+
+RUN apk add --update --virtual iputils-ping && \
+    apk --no-cache add ca-certificates && \
+    addgroup -S api && adduser --uid 19998 --shell /bin/false -S api -G api -h /home/api && \
+    cat /etc/passwd | grep api > /etc/passwd_api && \
+    pip install --upgrade cffi pip setuptools && \
+    pip wheel --no-cache-dir --no-deps --wheel-dir /api/wheels -r requirements.txt && \
+    find /usr/local \
+    \( -type d -a -name test -o -name tests \) \
+    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+    -exec rm -rf '{}' +
+
+FROM python:3.10.2-alpine3.15
+
+ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+
+COPY --from=builder /etc/passwd_api /etc/passwd
+COPY --from=builder /api/wheels /wheels
+COPY --from=builder /api/requirements.txt .
+
+RUN pip install --no-cache /wheels/* && mkdir -p /home/api && \
+    chown -R api /home/api && \
+    find /usr/local \
+    \( -type d -a -name test -o -name tests \) \
+    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' -o -name '*.pyi' \) \
+    -exec rm -rf '{}' +
+
+COPY --chown=api . /home/api
+
+USER api
+
+WORKDIR /home/api
+
+EXPOSE 8000
 
 CMD ["uvicorn", "app.main:app", "--host", "172.19.0.2", "--port", "8000"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,12 +1,42 @@
-FROM python:3.10.2
-
-RUN apt update && apt install iputils-ping -y
+FROM python:3.10.2-alpine3.15 AS builder
 
 WORKDIR /frontend
-COPY . .
 
-RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONDONTWRITEBYTECODE=1
 
+COPY ./requirements.txt .
+
+RUN apk add --update --virtual iputils-ping && \
+    apk --no-cache add ca-certificates && \
+    addgroup -S frontend && adduser --uid 19998 --shell /bin/false -S frontend -G frontend -h /home/frontend && \
+    cat /etc/passwd | grep frontend > /etc/passwd_frontend && \
+    pip install --upgrade cffi pip setuptools && \
+    pip wheel --no-cache-dir --no-deps --wheel-dir /frontend/wheels -r requirements.txt && \
+    find /usr/local \
+    \( -type d -a -name test -o -name tests \) \
+    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+    -exec rm -rf '{}' +
+
+FROM python:3.10.2-alpine3.15
+
+ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+
+COPY --from=builder /etc/passwd_frontend /etc/passwd
+COPY --from=builder /frontend/wheels /wheels
+COPY --from=builder /frontend/requirements.txt .
+
+RUN pip install --no-cache /wheels/* && mkdir -p /home/frontend && \
+    chown -R frontend /home/frontend && \
+    find /usr/local \
+    \( -type d -a -name test -o -name tests \) \
+    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' -o -name '*.pyi' \) \
+    -exec rm -rf '{}' +
+
+COPY --chown=frontend . /home/frontend
+
+USER frontend
+
+WORKDIR /home/frontend
 
 CMD ["python3", "main.py"]

--- a/parser/Dockerfile
+++ b/parser/Dockerfile
@@ -1,11 +1,42 @@
-FROM python:3.10.2
+FROM python:3.10.2-alpine3.15 AS builder
 
 WORKDIR /parser
-COPY . .
 
-RUN pip install --no-cache-dir -r requirements.txt
+ENV PYTHONDONTWRITEBYTECODE=1
 
+COPY ./requirements.txt .
+
+RUN addgroup -S parser && adduser --uid 19998 --shell /bin/false -S parser -G parser -h /home/parser && \
+    cat /etc/passwd | grep parser > /etc/passwd_parser && \
+    pip install --upgrade cffi pip setuptools && \
+    pip wheel --no-cache-dir --no-deps --wheel-dir /parser/wheels -r requirements.txt && \
+    find /usr/local \
+    \( -type d -a -name test -o -name tests \) \
+    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' \) \
+    -exec rm -rf '{}' +
+
+
+FROM python:3.10.2-alpine3.15
+
+ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV DISPLAY=:99
+
+COPY --from=builder /etc/passwd_parser /etc/passwd
+COPY --from=builder /parser/wheels /wheels
+COPY --from=builder /parser/requirements.txt .
+
+RUN pip install --no-cache /wheels/* && mkdir -p /home/parser && \
+    chown -R parser /home/parser && \
+    find /usr/local \
+    \( -type d -a -name test -o -name tests \) \
+    -o \( -type f -a -name '*.pyc' -o -name '*.pyo' -o -name '*.pyi' \) \
+    -exec rm -rf '{}' +
+
+COPY --chown=parser . /home/parser
+
+USER parser
+
+WORKDIR /home/parser
 
 CMD ["python3", "main.py"]


### PR DESCRIPTION
Currently, the project does not implement an optimal scenario for building docker images, which leads to excessively large image sizes and inefficient builds.

Before (on Mac):
campus_map_bot-api - 942,5 Mb
campus_map_bot-frontend - 913,8 Mb
campus_map_bot-parser - 873,6 Mb

<img width="700" alt="before" src="https://github.com/user-attachments/assets/89198460-302d-45be-b3da-3cfc062f1d37">

After (on Mac):
campus_map_bot-api - 107,9 Mb
campus_map_bot-frontend - 71,3 Mb
campus_map_bot-parser - 49,8 Mb

<img width="707" alt="after" src="https://github.com/user-attachments/assets/4d38c1bb-9e76-4b5e-9028-ccc2f0e65bd4">

